### PR TITLE
fix: add forms module and configure GitHub Pages deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     
     steps:
     - name: Checkout
@@ -31,5 +33,4 @@ jobs:
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./dist/gaulia-tech/browser
-        cname: # Deixe vazio se não tiver domínio personalizado
+        publish_dir: ./dist/gaulia-tech

--- a/angular.json
+++ b/angular.json
@@ -63,7 +63,7 @@
               },
               "sourceMap": false,
               "extractLicenses": true,
-              "baseHref": "/gaulia-tech/"
+                "baseHref": "/GauliaTechWebsite/"
             },
             "development": {
               "optimization": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,12 @@
       "name": "gaulia-tech",
       "version": "0.0.0",
       "dependencies": {
-        "@angular/animations": "^20.2.1",
-        "@angular/common": "^20.2.0",
-        "@angular/compiler": "^20.2.0",
-        "@angular/core": "^20.2.0",
-        "@angular/platform-browser": "^20.2.0",
+        "@angular/animations": "20.2.1",
+        "@angular/common": "20.2.1",
+        "@angular/compiler": "20.2.1",
+        "@angular/core": "20.2.1",
+        "@angular/forms": "20.2.1",
+        "@angular/platform-browser": "20.2.1",
         "@types/three": "^0.179.0",
         "three": "^0.179.1",
         "tslib": "^2.3.0",
@@ -554,6 +555,24 @@
         "zone.js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/forms": {
+      "version": "20.2.1",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.2.1.tgz",
+      "integrity": "sha512-SfkiHEIFPLtTKeaXUTpRfYnpJDxaeKiTi0YqfvzEjKE68qH0t+pQ4rL0Poch2/l4snP6JS1XzO/nDve1dk3vZw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "20.2.1",
+        "@angular/core": "20.2.1",
+        "@angular/platform-browser": "20.2.1",
+        "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build:prod": "ng build --configuration production",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "deploy": "ng build --configuration production --base-href /gaulia-tech/ && npx angular-cli-ghpages --dir=dist/gaulia-tech/browser"
+    "deploy": "ng build --configuration production --base-href /GauliaTechWebsite/ && npx angular-cli-ghpages --dir=dist/gaulia-tech"
   },
   "prettier": {
     "printWidth": 100,
@@ -24,11 +24,12 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/animations": "^20.2.1",
-    "@angular/common": "^20.2.0",
-    "@angular/compiler": "^20.2.0",
-    "@angular/core": "^20.2.0",
-    "@angular/platform-browser": "^20.2.0",
+    "@angular/animations": "20.2.1",
+    "@angular/common": "20.2.1",
+    "@angular/compiler": "20.2.1",
+    "@angular/core": "20.2.1",
+    "@angular/forms": "20.2.1",
+    "@angular/platform-browser": "20.2.1",
     "@types/three": "^0.179.0",
     "three": "^0.179.1",
     "tslib": "^2.3.0",

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,5 @@
 import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { HeaderComponent } from './components/header/header';
 import { FooterComponent } from './components/footer/footer';
 import { GlobeComponent } from './components/globe/globe';
@@ -6,7 +7,7 @@ import { GlobeComponent } from './components/globe/globe';
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [HeaderComponent, FooterComponent, GlobeComponent],
+  imports: [FormsModule, HeaderComponent, FooterComponent, GlobeComponent],
   templateUrl: './app.html',
   styleUrls: ['./app.scss']
 })


### PR DESCRIPTION
## Summary
- import Angular `FormsModule` into `AppComponent` for template-driven forms
- align Angular package versions and add `@angular/forms`
- configure GitHub Pages workflow and correct base href for deployment

## Testing
- `npm run build:prod`
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_b_68be00711e9883259a5aecd4d4e72e4a